### PR TITLE
Get server data from mine

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -179,6 +179,14 @@ listen {{ listener[1].get('name', listener[0]) }}
     server {{ server[1].get('name',server[0]) }} {{ server[1].host }}:{{ server[1].port }} {{ server[1].check }}
       {%- endfor -%}
     {%- endif -%}
+    {%- if 'mine_servers_module' in listener[1] and 'mine_servers' in listener[1] -%}
+      {%- for server, address in salt['mine.get'](listener[1].mine_servers, listener[1].mine_servers_module).items() -%}
+        {%- set port = salt['pillar.get']('haproxy:listeners:' + listener[0] + ':mine_servers_extras:port', '80') -%}
+        {%- set check = salt['pillar.get']('haproxy:listeners:' + listener[0] + ':mine_servers_extras:check', '') -%}
+        {%- set extra = salt['pillar.get']('haproxy:listeners:' + listener[0] + ':mine_servers_extras:extra', '') %}
+    server {{ server }} {{ address }}:{{ port }} {{ check }} {{ extra }}
+      {% endfor %}
+    {%- endif -%}
   {% endfor -%}
 {%- endif -%}
 {%- if 'frontends' in salt['pillar.get']('haproxy', {}) %}
@@ -318,6 +326,14 @@ backend {{ backend[1].get('name',backend[0]) }}
       {%- for server in backend[1].servers.iteritems() %}
     server {{ server[1].get('name',server[0]) }} {{ server[1].host }}:{{ server[1].port }} {{ server[1].check }} {{ server[1].get('extra', '') }}
       {% endfor -%}
+    {%- endif -%}
+    {%- if 'mine_servers_module' in backend[1] and 'mine_servers' in backend[1] -%}
+      {%- for server, address in salt['mine.get'](backend[1].mine_servers, backend[1].mine_servers_module).items() -%}
+        {%- set port = salt['pillar.get']('haproxy:backends:' + backend[0] + ':mine_servers_extras:port', '80') -%}
+        {%- set check = salt['pillar.get']('haproxy:backends:' + backend[0] + ':mine_servers_extras:check', '') -%}
+        {%- set extra = salt['pillar.get']('haproxy:backends:' + backend[0] + ':mine_servers_extras:extra', '') %}
+    server {{ server }} {{ address }}:{{ port }} {{ check }} {{ extra }}
+      {% endfor %}
     {%- endif -%}
   {% endfor -%}
 {%- endif -%}

--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -176,7 +176,7 @@ listen {{ listener[1].get('name', listener[0]) }}
     {%- endif -%}
     {%- if 'servers' in listener[1] -%}
       {%- for server in listener[1].servers.iteritems() %}
-    server {{ server[1].get('name',server[0]) }} {{ server[1].host }}:{{ server[1].port }} {{ server[1].check }}
+    server {{ server[1].get('name', server[0]) }} {{ server[1].host }}:{{ server[1].port }} {{ server[1].check }}
       {%- endfor -%}
     {%- endif -%}
     {%- if 'mine_servers_module' in listener[1] and 'mine_servers' in listener[1] -%}
@@ -267,7 +267,7 @@ frontend {{ frontend[1].get('name', frontend[0]) }}
 # Backend instances
 #------------------
   {%- for backend in salt['pillar.get']('haproxy:backends', {}).iteritems() %}
-backend {{ backend[1].get('name',backend[0]) }}
+backend {{ backend[1].get('name', backend[0]) }}
     {%- if 'balance' in backend[1] %}
     balance {{ backend[1].balance }}
     {%- endif -%}
@@ -324,7 +324,7 @@ backend {{ backend[1].get('name',backend[0]) }}
     {%- endif -%}
     {%- if 'servers' in backend[1] -%}
       {%- for server in backend[1].servers.iteritems() %}
-    server {{ server[1].get('name',server[0]) }} {{ server[1].host }}:{{ server[1].port }} {{ server[1].check }} {{ server[1].get('extra', '') }}
+    server {{ server[1].get('name', server[0]) }} {{ server[1].host }}:{{ server[1].port }} {{ server[1].check }} {{ server[1].get('extra', '') }}
       {% endfor -%}
     {%- endif -%}
     {%- if 'mine_servers_module' in backend[1] and 'mine_servers' in backend[1] -%}


### PR DESCRIPTION
Pillar can now be written as follows:

```
{% set id = grains['id'] %}
{% set domain = id.split('.', 1)[1] %}
haproxy:
  backends:
    backend0:
      balance: roundrobin
      options:
        - httpchk
        - httpchk HEAD / HTTP/1.1
      http_check:
        - expect status 200
      mine_servers: {{ 'app[0-9]*.' + domain }}
      mine_servers_module: my_custom_module.get_ip
      mine_servers_extras:
        port: 80
        check: check
        extra: maxconn 250
```
