### PR TITLE
Use 'ssl:intermediate' key for intermediate cert.

### DIFF
--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -55,6 +55,9 @@ haproxy.install:
     - contents: |
         {{ salt['pillar.get']('ssl:%s:key' % ssl_cert) | indent(8) }}
         {{ salt['pillar.get']('ssl:%s:certificate' % ssl_cert) | indent(8) }}
+        {%- if 'intermediate' in salt['pillar.get']('ssl:%s' % ssl_cert) %}
+        {{ salt['pillar.get']('ssl:%s:intermediate' % ssl_cert) | indent(8) }}
+        {% endif %}
         {%- if 'ca' in salt['pillar.get']('ssl:%s' % ssl_cert) %}
         {{ salt['pillar.get']('ssl:%s:ca' % ssl_cert) | indent(8) }}
         {% endif %}


### PR DESCRIPTION
I was tempted to just rename 'ca' to 'intermediate' (which is probably how CA is typically being used), but that could break a few things.
