### PR TITLE
Update OCSP

### DIFF
--- a/haproxy/files/update_ocsp
+++ b/haproxy/files/update_ocsp
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+#
+# (c) 2015 SitePoint Pty Ltd
+# Maintainer: Adam Bolte
+#
+# Add HAProxy OCSP Stapling support based on the Mozilla instructions:
+# https://wiki.mozilla.org/Security/Server_Side_TLS#Haproxy
+
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+from pprint import pprint
+from subprocess import PIPE, Popen, check_call
+
+ocsp_file_ext = '.pem.ocsp'
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-v', '--verbose', action='store_true')
+parser.add_argument('OCSP_OUT_DIR', help="Where to write the OCSP files to.")
+parser.parse_args()
+args = parser.parse_args()
+ocsp_out_dir = args.OCSP_OUT_DIR
+verbose = args.verbose
+
+# Import the Salt client library
+try:
+    import salt.client
+except ImportError as e:
+    sys.stderr.write(
+        "Failed to load the Salt Stack client library.\n" + \
+        "Try installing the salt-common package.\n"
+    )
+    sys.exit(1)
+
+# Create a temporary directory.
+td = tempfile.mkdtemp(prefix='update-ocsp-')
+
+# Create a local client Caller object
+caller = salt.client.Caller()
+
+cert_files = {}
+
+# Make calls with the cmd method
+try:
+    results = caller.function('pillar.get', 'ssl')
+except Exception as e:
+    sys.stderr.write("Failure:\n%r\n" % e)
+    sys.exit(1)
+
+
+for cert in results:
+    cert_files.update({cert: {}})
+
+    results[cert].update({'ocsp': ''})
+    for cert_type in ('intermediate', 'ca', 'certificate', 'ocsp'):
+
+        if cert_type in results[cert]:
+            try:
+                os.mkdir(os.path.join(td, cert), 0700)
+            except OSError as e:
+                pass
+
+            # Inconsistent Pillar data structure. 'ca' should be treated
+            # in the same way 'intermediate' certificates are treated.
+            if cert_type == 'ca':
+                cert_type = 'intermediate'
+                write_flag = os.O_CREAT | os.O_APPEND
+                write_mode = 'a'
+            else:
+                write_flag = os.O_CREAT | os.O_WRONLY
+                write_mode = 'w'
+
+            if cert_type != 'ocsp':
+                file_name = os.path.join(td, cert, cert_type)
+            else:
+                file_name = os.path.join(ocsp_out_dir, cert + ocsp_file_ext)
+            cert_files[cert].update({cert_type: file_name})
+
+            if cert_type in results[cert]:
+                with open(file_name, write_mode) as fh:
+                    cert_start = False
+                    for line in results[cert][cert_type].splitlines():
+                        if line == '-----BEGIN CERTIFICATE-----':
+                            cert_start = True
+                        if cert_start:
+                            fh.write(line + '\n')
+
+first_line = True
+for cert in cert_files:
+    get_ocsp_cmd = [
+        'openssl', 'x509', '-in', cert_files[cert]['certificate'], '-text'
+    ]
+    p1 = Popen(get_ocsp_cmd, stdout=PIPE)
+    p2 = Popen(['grep', 'OCSP'], stdin=p1.stdout, stdout=PIPE)
+    p1.stdout.close()
+    ocsp_url = re.sub(r'^[^:]*:', '', p2.communicate()[0]).rstrip()
+
+    if not len(ocsp_url):
+        continue
+
+    if verbose and not first_line:
+        print
+    else:
+        first_line = False
+
+    openssl_cmd = ['openssl', 'ocsp', '-noverify']
+
+    if 'intermediate' in cert_files[cert]:
+        openssl_cmd.extend(['-issuer', cert_files[cert]['intermediate']])
+
+    if 'certificate' in cert_files[cert]:
+        openssl_cmd.extend(['-cert', cert_files[cert]['certificate']])
+
+    openssl_cmd.extend([
+        '-url', ocsp_url, '-no_nonce',
+        '-respout', cert_files[cert]['ocsp']
+    ])
+
+    if verbose:
+        print "# %s\n$ %s" % (cert, " ".join(openssl_cmd))
+        check_call(openssl_cmd)
+    else:
+        FNULL = open(os.devnull, 'w')
+        check_call(openssl_cmd, stdout=FNULL)
+
+# Clean-up operation
+for temp_cert in cert_files:
+    for cert_file in cert_files[temp_cert]:
+        if (
+            os.path.isfile(cert_files[temp_cert][cert_file]) and
+            (
+                os.path.getsize(cert_files[temp_cert][cert_file]) == 0
+                or not cert_files[temp_cert][cert_file].endswith(ocsp_file_ext)
+            )
+        ):
+            os.remove(cert_files[temp_cert][cert_file])
+            if not cert_files[temp_cert][cert_file].endswith(ocsp_file_ext):
+                cert_dir = os.path.dirname(cert_files[temp_cert][cert_file])
+
+    os.rmdir(cert_dir)
+os.rmdir(td)

--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -66,15 +66,18 @@ Restart rsyslog on haproxy package install:
     - source: salt://haproxy/files/update_ocsp
     - requires:
       - pkg: haproxy
+  cmd.wait:
+    - name: /usr/local/sbin/update_ocsp /etc/haproxy/certs
+    - require:
+      - file: /usr/local/sbin/update_ocsp
+
+Schedule regular update_ocsp executions via cron:
   cron.present:
+    - name: /usr/local/sbin/update_ocsp /etc/haproxy/certs
     - identifier: HAPROXY_OCSP_UPDATE
     - user: root
     - minute: 0
     - hour: '*/6'
-    - require:
-      - file: /usr/local/sbin/update_ocsp
-  cmd.wait:
-    - name: /usr/local/sbin/update_ocsp /etc/haproxy/certs
     - require:
       - file: /usr/local/sbin/update_ocsp
 

--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -19,6 +19,7 @@ haproxy.install:
 {% endfor %}
 {% endif %}
 
+
 {#
  # See bug report: haproxy install should restart rsyslog
  # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=790871
@@ -57,6 +58,26 @@ Restart rsyslog on haproxy package install:
     - require:
       - pkg: haproxy
 
+/usr/local/sbin/update_ocsp:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: '0700'
+    - source: salt://haproxy/files/update_ocsp
+    - requires:
+      - pkg: haproxy
+  cron.present:
+    - identifier: HAPROXY_OCSP_UPDATE
+    - user: root
+    - minute: 0
+    - hour: '*/6'
+    - require:
+      - file: /usr/local/sbin/update_ocsp
+  cmd.wait:
+    - name: /usr/local/sbin/update_ocsp /etc/haproxy/certs
+    - require:
+      - file: /usr/local/sbin/update_ocsp
+
 {% for ssl_cert in salt['pillar.get']('ssl') %}
 /etc/haproxy/certs/{{ ssl_cert }}.pem:
   file.managed:
@@ -74,5 +95,7 @@ Restart rsyslog on haproxy package install:
         {% endif %}
     - require:
       - file: /etc/haproxy/certs
+    - watch_in:
+      - cmd: /usr/local/sbin/update_ocsp
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Should help reduce SSL overhead by avoiding a separate request to the CA to check the certificate status.

It's a bit ugly TBH, but it does the job. 
