### PR TITLE
Allow include statement to be defined in pillar.

### DIFF
--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -1,4 +1,14 @@
-# Because on Ubuntu we don't have a current HAProxy in the usual repo, we add a PPA
+{% if salt['pillar.get']('haproxy:include') %}
+include:
+{% for item in salt['pillar.get']('haproxy:include') %}
+  - {{ item }}
+{% endfor %}
+{% endif %}
+
+{#
+  Because on Ubuntu we don't have a current HAProxy in the usual repo,
+  we add a PPA
+#}
 {% if salt['grains.get']('osfullname') == 'Ubuntu' %}
 haproxy_ppa_repo:
   pkgrepo.managed:


### PR DESCRIPTION
If you have requirement statements defined in Pillar already (which presumably reference a different state), running the haproxy state directly will fail as dependencies are missing.

This patch provides a way to address this potential issue.
