### PR TITLE
Keep 7 days of haproxy logs by default (was 52).

### DIFF
--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -59,6 +59,13 @@ Restart rsyslog on haproxy package install:
     - require:
       - pkg: haproxy.install
 
+/etc/logrotate.d/haproxy:
+  file.replace:
+    - pattern: '^\s*rotate\s+.*$'
+    - repl: '    rotate {{ salt['pillar.get']('haproxy:log_rotate_days', '7') }}'
+    - require:
+      - pkg: haproxy
+
 {% if 'ssl' in salt['pillar.items']() %}
 /etc/haproxy/certs:
   file.directory:


### PR DESCRIPTION
52 days was causing our productions servers to run out of space.
