### PR TITLE
Don't create logrotate backup files.

### DIFF
--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -63,6 +63,7 @@ Restart rsyslog on haproxy package install:
   file.replace:
     - pattern: '^\s*rotate\s+.*$'
     - repl: '    rotate {{ salt['pillar.get']('haproxy:log_rotate_days', '7') }}'
+    - backup: False
     - require:
       - pkg: haproxy
 


### PR DESCRIPTION
Doing so causes logrotate to detect duplicate entries and print
warnings, which in turn will result in daily e-mails via cron.
