### PR TITLE
update_ocsp improvements

### DIFF
--- a/haproxy/files/update_ocsp
+++ b/haproxy/files/update_ocsp
@@ -57,7 +57,13 @@ def setup_argparser():
 def get_certs_from_pillar():
     """Return 'ssl' keys from Salt pillar as a dict"""
     # Create a local client Caller object
-    caller = salt.client.Caller()
+    try:
+        caller = salt.client.Caller()
+    except salt.exceptions.SaltClientError:
+        sys.stderr.write(
+            "Error: Failed to authenticate with the salt master.\n"
+        )
+        sys.exit(1)
 
     # Make calls with the cmd method
     try:

--- a/haproxy/files/update_ocsp
+++ b/haproxy/files/update_ocsp
@@ -24,15 +24,14 @@ try:
     import salt.client
 except ImportError as e:
     sys.stderr.write(
-        "Failed to load the Salt Stack client library.\n" + \
-        "Try installing the salt-common package.\n"
+        os.join(["Failed to load the Salt Stack client library.\n",
+                 "Try installing the salt-common package.\n"])
     )
     sys.exit(1)
 
 
 def setup_argparser():
-    """Return a argparse.ArgumentParser instance."""
-
+    """Return a argparse.ArgumentParser instance"""
     parser = argparse.ArgumentParser()
     parser.add_argument('-v', '--verbose', action='store_true')
     parser.add_argument(
@@ -56,8 +55,7 @@ def setup_argparser():
 
 
 def get_certs_from_pillar():
-    """Return 'ssl' keys from Salt pillar as a dict."""
-
+    """Return 'ssl' keys from Salt pillar as a dict"""
     # Create a local client Caller object
     caller = salt.client.Caller()
 
@@ -115,7 +113,7 @@ def write_certs_to_disk(ssl_pillar):
                             if line == '-----BEGIN CERTIFICATE-----':
                                 cert_start = True
                             if cert_start:
-                                fh.write(line + '\n')
+                                fh.write(''.join([line, '\n']))
 
     return cert_files
 
@@ -123,7 +121,23 @@ def write_certs_to_disk(ssl_pillar):
 def execute_openssl_ocsp_command(cert_file_locations, verbose):
     """Execute openssl ocsp to generate OCSP file
 
+    The file will be saved to cert_file_locations[cert]['ocsp'].
+    """
+    def verbose_output(first_line, cert, tw):
+        if not first_line:
+            print
+        else:
+            first_line = False
+
+        print "# %s\n$" % cert,
+        print tw.fill(" ".join(openssl_cmd)).replace('\n', ' \\\n')
+
+        return first_line
+
     first_line = True
+    tw = textwrap.TextWrapper(
+        width=78, break_on_hyphens=False, subsequent_indent='    '
+    )
     for cert in cert_file_locations:
         get_ocsp_cmd = [
             'openssl', 'x509', '-in',
@@ -137,11 +151,6 @@ def execute_openssl_ocsp_command(cert_file_locations, verbose):
 
         if not len(ocsp_url):
             continue
-
-        if verbose and not first_line:
-            print
-        else:
-            first_line = False
 
         openssl_cmd = ['openssl', 'ocsp', '-noverify']
 
@@ -161,16 +170,19 @@ def execute_openssl_ocsp_command(cert_file_locations, verbose):
             '-respout', cert_file_locations[cert]['ocsp']
         ])
 
-        if verbose:
-            print "# %s\n$" % cert,
-            tw = textwrap.TextWrapper(
-                width=78, break_on_hyphens=False, subsequent_indent='    '
+        try:
+            if verbose:
+                first_line = verbose_output(first_line, cert, tw)
+                check_call(openssl_cmd)
+            else:
+                FNULL = open(os.devnull, 'w')
+                check_call(openssl_cmd, stdout=FNULL)
+        except subprocess.CalledProcessError:
+            sys.stderr.write(
+                "Error: Failed to fetch OCSP file from '{0}'.".format(
+                    ocsp_url
+                )
             )
-            print tw.fill(" ".join(openssl_cmd)).replace('\n', ' \\\n')
-            check_call(openssl_cmd)
-        else:
-            FNULL = open(os.devnull, 'w')
-            check_call(openssl_cmd, stdout=FNULL)
             if os.path.isfile(cert_file_locations[cert]['ocsp']):
                 os.remove(cert_file_locations[cert]['ocsp'])
             # Don't exit here, because other certs may still be able

--- a/haproxy/files/update_ocsp
+++ b/haproxy/files/update_ocsp
@@ -10,6 +10,8 @@
 import argparse
 import os
 import re
+import shutil
+import stat
 import sys
 import tempfile
 import textwrap
@@ -69,12 +71,11 @@ def get_certs_from_pillar():
     return results
 
 
-def write_certs_to_disk(ssl_pillar, ocsp_out_dir):
-    """Write all public certs in ssl_pillar to individual files.
+def write_certs_to_disk(ssl_pillar):
+    """Write all public certs in ssl_pillar to individual files
 
     The location of each file is specified in the returned dictionary.
     """
-
     cert_files = {}
 
     # Create a temporary directory.
@@ -103,12 +104,7 @@ def write_certs_to_disk(ssl_pillar, ocsp_out_dir):
                     write_flag = os.O_CREAT | os.O_WRONLY
                     write_mode = 'w'
 
-                if cert_type != 'ocsp':
-                    file_name = os.path.join(td, cert, cert_type)
-                else:
-                    file_name = os.path.join(
-                        ocsp_out_dir, cert + ocsp_file_ext
-                    )
+                file_name = os.path.join(td, cert, cert_type)
 
                 cert_files[cert].update({cert_type: file_name})
 
@@ -124,8 +120,8 @@ def write_certs_to_disk(ssl_pillar, ocsp_out_dir):
     return cert_files
 
 
-def construct_openssl_ocsp_command(cert_file_locations, verbose):
-    """To be determined."""
+def execute_openssl_ocsp_command(cert_file_locations, verbose):
+    """Execute openssl ocsp to generate OCSP file
 
     first_line = True
     for cert in cert_file_locations:
@@ -175,32 +171,53 @@ def construct_openssl_ocsp_command(cert_file_locations, verbose):
         else:
             FNULL = open(os.devnull, 'w')
             check_call(openssl_cmd, stdout=FNULL)
+            if os.path.isfile(cert_file_locations[cert]['ocsp']):
+                os.remove(cert_file_locations[cert]['ocsp'])
+            # Don't exit here, because other certs may still be able
+            # to be processed, and by this point we'll need to execute
+            # clean-up operations.
+
+
+def install_ocsp_certificates(cert_file_locations, ocsp_out_dir):
+    """Copy good certs from temporary location to final target name"""
+    ocsp_file_ext = '.pem.ocsp'
+    for cert, keys in cert_file_locations.items():
+        if keys.get('ocsp', None):
+            if (
+                os.path.isfile(keys['ocsp']) and
+                (os.path.getsize(keys['ocsp']) > 0)
+            ):
+                target_location = os.path.join(
+                    ocsp_out_dir, ''.join([cert, ocsp_file_ext])
+                )
+                # Copy the file.
+                try:
+                    shutil.copy(keys['ocsp'], target_location)
+                    os.chmod(
+                        target_location,
+                        stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | \
+                        stat.S_IROTH
+                    )
+                    os.chown(target_location, 0, 0)
+                except OSError as e:
+                    sys.stderr.write(
+                        "Error: Failed to update '{0}' OCSP file.".format(
+                            target_location
+                        )
+                    )
 
 
 def clean_up_certs(cert_file_locations):
-    """Clean up temporary and empty files."""
-
+    """Clean up temporary and empty files"""
     for temp_cert in cert_file_locations:
         for cert_file in cert_file_locations[temp_cert]:
-            if (
-                os.path.isfile(
+            if os.path.isfile(
                     cert_file_locations[temp_cert][cert_file]
-                ) and (
-                    os.path.getsize(
-                        cert_file_locations[temp_cert][cert_file]
-                    ) == 0 or not
-                    cert_file_locations[temp_cert][cert_file].endswith(
-                        ocsp_file_ext
-                    )
-                )
             ):
                 os.remove(cert_file_locations[temp_cert][cert_file])
-                if not cert_file_locations[temp_cert][cert_file].endswith(
-                    ocsp_file_ext
-                ):
-                    cert_dir = os.path.dirname(
-                        cert_file_locations[temp_cert][cert_file]
-                    )
+                cert_dir = os.path.dirname(
+                    cert_file_locations[temp_cert][cert_file]
+                )
 
         os.rmdir(cert_dir)
         base_dir = os.path.dirname(cert_dir)
@@ -208,14 +225,9 @@ def clean_up_certs(cert_file_locations):
 
 
 if __name__ == "__main__":
-    ocsp_file_ext = '.pem.ocsp'
-
     args = setup_argparser()
-
     ssl_pillar = get_certs_from_pillar()
-    cert_file_locations = write_certs_to_disk(
-        ssl_pillar, args['ocsp_out_dir']
-    )
-
-    construct_openssl_ocsp_command(cert_file_locations, args['verbose'])
+    cert_file_locations = write_certs_to_disk(ssl_pillar)
+    execute_openssl_ocsp_command(cert_file_locations, args['verbose'])
+    install_ocsp_certificates(cert_file_locations, args['ocsp_out_dir'])
     clean_up_certs(cert_file_locations)


### PR DESCRIPTION
Error handling is improved as per the commit messages.

Hopefully helps Brad and I avoid getting e-mails like
```
Error querying OCSP responder
140440052991632:error:27076072:OCSP routines:PARSE_HTTP_LINE1:server response error:ocsp_ht.c:314:Code=404,Reason=Not Found
Traceback (most recent call last):
  File "/usr/local/sbin/update_ocsp", line 220, in <module>
    construct_openssl_ocsp_command(cert_file_locations, args['verbose'])
  File "/usr/local/sbin/update_ocsp", line 177, in construct_openssl_ocsp_command
    check_call(openssl_cmd, stdout=FNULL)
  File "/usr/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['openssl', 'ocsp', '-noverify', '-issuer', '/tmp/update-ocsp-oA9ZDx/sitepoint.com-ev-exp_20170803/intermediate', '-cert',
'/tmp/update-ocsp-oA9ZDx/sitepoint.com-ev-exp_20170803/certificate', '-url', 'http://ocsp.ssl.com', '-no_nonce', '-header', 'HOST', 'ocsp.ssl.com', '-respout',
'/etc/haproxy/certs/sitepoint.com-ev-exp_20170803.pem.ocsp']' returned non-zero exit status 1
```
and finding an empty `/etc/haproxy/certs/sitepoint.com-ev-exp_20170803.pem.ocsp` file in production.