### PR TITLE
Have haproxy-formula manage logrotate tweaks

### DIFF
--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -5,10 +5,7 @@ include:
 {% endfor %}
 {% endif %}
 
-{#
-  Because on Ubuntu we don't have a current HAProxy in the usual repo,
-  we add a PPA
-#}
+# If on Ubuntu, add a PPA to use the latest HAProxy releases.
 {% if salt['grains.get']('osfullname') == 'Ubuntu' %}
 haproxy_ppa_repo:
   pkgrepo.managed:
@@ -29,11 +26,8 @@ haproxy.install:
 {% endfor %}
 {% endif %}
 
-
-{#
- # See bug report: haproxy install should restart rsyslog
- # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=790871
- #}
+# See bug report: haproxy install should restart rsyslog
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=790871
 Restart rsyslog on haproxy package install:
   cmd.wait:
     - name: invoke-rc.d rsyslog restart
@@ -41,10 +35,8 @@ Restart rsyslog on haproxy package install:
     - watch:
       - pkg: haproxy
 
-{#
- # This is so HAProxy can confirm Squid is operational. The only known
- # alternative is running a separate webserver for a single file.
- #}
+# This is so HAProxy can confirm Squid is operational. The only known
+# alternative is running a separate webserver for a single file.
 /etc/haproxy/errors/200.http:
   file.managed:
     - contents: |
@@ -127,6 +119,7 @@ Delete {{ setting }} from {{ logrotate_config }}:
 {% endfor %}
 {% endif %}
 
+# Handle OCSP stapling.
 {% if 'ssl' in salt['pillar.items']() %}
 /etc/haproxy/certs:
   file.directory:

--- a/pillar.example
+++ b/pillar.example
@@ -5,6 +5,13 @@
 haproxy:
   enabled: True
   config_file_path: /etc/haproxy/haproxy.cfg
+  logrotate:
+    updates:
+      daily: ''
+      rotate: '5'
+    deletes:
+      - badoption
+  logrotate_file_path: /etc/logrotate.d/haproxy
   global:
     stats:
       enable: True


### PR DESCRIPTION
By default, the haproxy logrotate file on Debian looks as follows:
```
/var/log/haproxy.log {
    daily
    rotate 5
    missingok
    notifempty
    compress
    delaycompress
    postrotate
        invoke-rc.d rsyslog rotate >/dev/null 2>&1 || true
    endscript
}
```

We can't easily append options to the file since there is a `}` at the end. Additionally, some settings take arguments (such as `rotate` in the example above) which might require adjusting (or even removal). Both of these use cases are handled now handled by this PR.

This does not yet handle the `postrotate`/`endscript` section, but I have an idea on how to tackle that when I need to.

The point of this is that I would ultimately like to have HAProxy logs uploaded to an S3 bucket during rotation. As such, a number of logrotate options are expected to require changing. I don't want to clobber the defaults provided by Debian, since those might change with new releases or even as updates are pushed out.