### PR TITLE
Have update_ocsp import entire subprocess module

### DIFF
--- a/haproxy/files/update_ocsp
+++ b/haproxy/files/update_ocsp
@@ -11,11 +11,11 @@ import os
 import re
 import shutil
 import stat
+import subprocess
 import sys
 import tempfile
 import textwrap
 from pprint import pprint
-from subprocess import PIPE, Popen, check_call
 from urlparse import urlparse
 
 # Import the Salt client library
@@ -149,8 +149,9 @@ def execute_openssl_ocsp_command(cert_file_locations, verbose):
             'openssl', 'x509', '-in',
             cert_file_locations[cert]['certificate'], '-text'
         ]
-        p1 = Popen(get_ocsp_cmd, stdout=PIPE)
-        p2 = Popen(['grep', 'OCSP'], stdin=p1.stdout, stdout=PIPE)
+        p1 = subprocess.Popen(get_ocsp_cmd, stdout=subprocess.PIPE)
+        p2 = subprocess.Popen(['grep', 'OCSP'], stdin=p1.stdout,
+                              stdout=subprocess.PIPE)
         p1.stdout.close()
         ocsp_url = re.sub(r'^[^:]*:', '', p2.communicate()[0]).rstrip()
         ocsp_host = urlparse(ocsp_url).netloc
@@ -179,10 +180,10 @@ def execute_openssl_ocsp_command(cert_file_locations, verbose):
         try:
             if verbose:
                 first_line = verbose_output(first_line, cert, tw)
-                check_call(openssl_cmd)
+                subprocess.check_call(openssl_cmd)
             else:
                 FNULL = open(os.devnull, 'w')
-                check_call(openssl_cmd, stdout=FNULL)
+                subprocess.check_call(openssl_cmd, stdout=FNULL)
         except subprocess.CalledProcessError:
             sys.stderr.write(
                 "Error: Failed to fetch OCSP file from '{0}'.".format(


### PR DESCRIPTION
We previously missed importing the `subprocess.CalledProcessError` exception handler (line 187), so the exception handler would trigger an exception.