### PR TITLE
Add support for pillar-defined socket arguments

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -28,7 +28,16 @@ global
 {%- if salt['pillar.get']('haproxy:global:stats:enable', 'no') == True %}
 
     # Stats support is currently limited to socket mode
-    stats socket {{ salt['pillar.get']('haproxy:global:stats:socketpath', '/tmp/ha_stats.sock') }}
+    stats socket {{
+      salt['pillar.get'](
+        'haproxy:global:stats:socketpath', '/tmp/ha_stats.sock'
+      )
+    }} {%-
+      if 'options' in salt['pillar.get']('haproxy:global:stats', {})
+    -%} {%-
+        for option in salt['pillar.get']('haproxy:global:stats:options')
+      %} {{ option }} {%- endfor -%}
+    {%- endif -%}
 {%- endif %}
 
 


### PR DESCRIPTION
Ideally we should be removing instances from the load balancer whilst they are being upgraded, to avoid a very brief outage during deployment that happened to show up in Wormly this morning. The proposed solution [here](https://docs.ansible.com/ansible/guide_rolling_upgrade.html) looks like the way to go (well, aside from using the wrong configuration management tool!). To do that, we need to adjust some permission directives associated with the socket file.

This can now be achieved via a pillar file. eg
```
haproxy:
  global:
    stats:
      enable: True
      socketpath: /var/lib/haproxy/stats
      options:
        - mode 600
        - level admin
```

This will result in the following:

```
----------
          ID: haproxy.config
    Function: file.managed
        Name: /etc/haproxy/haproxy.cfg
      Result: None
     Comment: The file /etc/haproxy/haproxy.cfg is set to be changed
     Started: 11:24:56.373164
    Duration: 418.147 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -20,7 +20,7 @@
                       ...<snip>...
                   
                       # Stats support is currently limited to socket mode
                  -    stats socket /var/lib/haproxy/stats
                  +    stats socket /var/lib/haproxy/stats mode 600 level admin
                   
                   
                   #------------------
----------
          ID: haproxy.service
    Function: service.running
        Name: haproxy
      Result: None
     Comment: Service is set to be reloaded
     Started: 11:24:56.812687
    Duration: 8.918 ms
     Changes:   
```

In this example, we can now use socat (as root) to disable backend servers during an upgrade, and to re-enable them again when complete.