### PR TITLE
Remove redundant watch_in

### DIFF
--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -19,8 +19,6 @@ haproxy_ppa_repo:
     - ppa: vbernat/haproxy-1.5
     - require_in:
       - pkg: haproxy.install
-    - watch_in:
-      - pkg: haproxy.install
 {% endif %}
 
 haproxy.install:


### PR DESCRIPTION
We're not using the `pkg` `mod_watch` argument.
