### PR TITLE
Add a work-around for Salt issue #48277

### DIFF
--- a/haproxy/init.sls
+++ b/haproxy/init.sls
@@ -11,3 +11,11 @@ include:
   - haproxy.install
   - haproxy.service
   - haproxy.config
+
+# We need something more in an sls file than a single include
+# statement to avoid Salt issue #48277.
+# https://github.com/saltstack/salt/issues/48277
+# The fix is expected to arrive in 2017.7.8 or 2018.8.3, after which
+# point this hack can disappear.
+Work-around for Salt issue 48277:
+  test.succeed_without_changes


### PR DESCRIPTION
https://github.com/saltstack/salt/issues/48277

This was the main blocker preventing us from upgrading to 2018.3. It's important this was fixed since I started observing this in the late 2017.7 series also, and will need to get this out to production before attempting to roll out updated AMIs.