### PR TITLE
Update HTTP request/response support

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -117,6 +117,11 @@ listen {{ listener_config.name|default(listener) }}
     acl {{ acl }}
       {%- endfor %}
     {%- endif %}
+    {%- if 'http_request' in listener_config %}
+      {%- for http_request in listener_config.http_request %}
+    http-request {{ http_request }}
+      {%- endfor %}
+    {%- endif %}
     {%- if 'redirects' in listener_config %}
       {%- for front_redirect in listener_config.redirects %}
     redirect {{ front_redirect }}

--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -122,6 +122,11 @@ listen {{ listener_config.name|default(listener) }}
     http-request {{ http_request }}
       {%- endfor %}
     {%- endif %}
+    {%- if 'http_request' in listener_config %}
+      {%- for http_request in listener_config.http_request %}
+    http-request {{ http_request }}
+      {%- endfor %}
+    {%- endif %}
     {%- if 'redirects' in listener_config %}
       {%- for front_redirect in listener_config.redirects %}
     redirect {{ front_redirect }}
@@ -233,6 +238,11 @@ frontend {{ frontend_config.name|default(frontend) }}
     http-request {{ http_request }}
       {%- endfor %}
     {%- endif %}
+    {%- if 'http_response' in frontend_config %}
+      {%- for http_response in frontend_config.http_response %}
+    http-response {{ http_response }}
+      {%- endfor %}
+    {%- endif %}
     {%- if 'reqirep' in frontend_config %}
       {%- for reqirep in frontend_config.reqirep %}
     reqirep {{ reqirep }}
@@ -301,6 +311,11 @@ backend {{ backend_config.name|default(backend) }}
     {%- if 'acls' in backend_config %}
       {%- for acl in backend_config.acls %}
     acl {{ acl }}
+      {%- endfor %}
+    {%- endif %}
+    {%- if 'http_request' in backend_config %}
+      {%- for http_request in backend_config.http_request %}
+    http-request {{ http_request }}
       {%- endfor %}
     {%- endif %}
     {%- if 'http_request' in backend_config %}


### PR DESCRIPTION
This ensures `http-request` and `http-response` directives are supported in each section they are permitted, based on the HAProxy 1.7 docs.

The `http-request` fix was added here just because I noticed it while I was there. The `http-response` support is more interesting, as with the upcoming removal of the legacy forums, we'll be one step closer to supporting HSTS to improve our security. Setting the `Strict-Transport-Security` response header via the HAProxy frontend is probably the smartest way to go about enabling this.