### PR TITLE
Fix http-response and add stick-table support

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -122,9 +122,9 @@ listen {{ listener_config.name|default(listener) }}
     http-request {{ http_request }}
       {%- endfor %}
     {%- endif %}
-    {%- if 'http_request' in listener_config %}
-      {%- for http_request in listener_config.http_request %}
-    http-request {{ http_request }}
+    {%- if 'http_response' in listener_config %}
+      {%- for http_response in listener_config.http_response %}
+    http-response {{ http_response }}
       {%- endfor %}
     {%- endif %}
     {%- if 'redirects' in listener_config %}
@@ -318,9 +318,9 @@ backend {{ backend_config.name|default(backend) }}
     http-request {{ http_request }}
       {%- endfor %}
     {%- endif %}
-    {%- if 'http_request' in backend_config %}
-      {%- for http_request in backend_config.http_request %}
-    http-request {{ http_request }}
+    {%- if 'http_response' in backend_config %}
+      {%- for http_response in backend_config.http_response %}
+    http-response {{ http_response }}
       {%- endfor %}
     {%- endif %}
     {%- if 'reqirep' in backend_config %}

--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -127,6 +127,11 @@ listen {{ listener_config.name|default(listener) }}
     http-response {{ http_response }}
       {%- endfor %}
     {%- endif %}
+    {%- if 'stick_table' in listener_config %}
+      {%- for stick_table in listener_config.stick_table %}
+    stick-table {{ stick_table }}
+      {%- endfor %}
+    {%- endif %}
     {%- if 'redirects' in listener_config %}
       {%- for front_redirect in listener_config.redirects %}
     redirect {{ front_redirect }}
@@ -243,6 +248,11 @@ frontend {{ frontend_config.name|default(frontend) }}
     http-response {{ http_response }}
       {%- endfor %}
     {%- endif %}
+    {%- if 'stick_table' in frontend_config %}
+      {%- for stick_table in frontend_config.stick_table %}
+    stick-table {{ stick_table }}
+      {%- endfor %}
+    {%- endif %}
     {%- if 'reqirep' in frontend_config %}
       {%- for reqirep in frontend_config.reqirep %}
     reqirep {{ reqirep }}
@@ -321,6 +331,11 @@ backend {{ backend_config.name|default(backend) }}
     {%- if 'http_response' in backend_config %}
       {%- for http_response in backend_config.http_response %}
     http-response {{ http_response }}
+      {%- endfor %}
+    {%- endif %}
+    {%- if 'stick_table' in backend_config %}
+      {%- for stick_table in backend_config.stick_table %}
+    stick-table {{ stick_table }}
       {%- endfor %}
     {%- endif %}
     {%- if 'reqirep' in backend_config %}


### PR DESCRIPTION
This is intended to be used in limiting the number of requests someone can make to wp-login.php in a given time frame.