### PR TITLE
Ensure /sbin:/usr/sbin is in the update_ocsp path

### DIFF
--- a/haproxy/files/update_ocsp
+++ b/haproxy/files/update_ocsp
@@ -29,6 +29,16 @@ except ImportError:
     sys.exit(1)
 
 
+def extend_system_path(add_paths):
+    """Add list of additional directories to front of PATH"""
+    system_path = os.environ["PATH"].split(':')
+    for path in add_paths[::-1]:
+        if path in system_path:
+            system_path.remove(path)
+        system_path.insert(0, path)
+    os.environ["PATH"] = os.pathsep.join(system_path)
+
+
 def setup_argparser():
     """Return a argparse.ArgumentParser instance"""
     parser = argparse.ArgumentParser()
@@ -250,6 +260,7 @@ def clean_up_certs(cert_file_locations):
 
 def main():
     """Begin execution"""
+    extend_system_path(['/sbin', '/usr/sbin'])
     args = setup_argparser()
     ssl_pillar = get_certs_from_pillar()
     cert_file_locations = write_certs_to_disk(ssl_pillar)

--- a/haproxy/files/update_ocsp
+++ b/haproxy/files/update_ocsp
@@ -4,7 +4,7 @@
 Based on the Mozilla instructions:
 https://wiki.mozilla.org/Security/TLS_Configurations#Haproxy
 
-(c) 2017,2019 SitePoint Pty Ltd
+(c) 2015,2017,2019-2020 SitePoint Pty Ltd
 Maintainer: Adam Bolte
 """
 

--- a/haproxy/files/update_ocsp
+++ b/haproxy/files/update_ocsp
@@ -8,6 +8,8 @@ https://wiki.mozilla.org/Security/TLS_Configurations#Haproxy
 Maintainer: Adam Bolte
 """
 
+from __future__ import print_function
+
 import argparse
 import os
 import re
@@ -17,7 +19,11 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-from urlparse import urlparse
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 # Import the Salt client library
 try:
@@ -104,7 +110,7 @@ def write_certs_to_disk(ssl_pillar):
             if cert_type in ssl_pillar[cert] and (
                     ssl_pillar[cert][cert_type] or cert_type == 'ocsp'):
                 try:
-                    os.mkdir(os.path.join(temp_dir, cert), 0700)
+                    os.mkdir(os.path.join(temp_dir, cert), 0o700)
                 except OSError:
                     pass
 
@@ -144,12 +150,12 @@ def execute_openssl_ocsp_command(cert_file_locations, verbose):
     def verbose_output(first_line, cert, text_wrapper):
         """Print certificates to stdout"""
         if not first_line:
-            print
+            print()
         else:
             first_line = False
 
-        print "# %s\n$" % cert,
-        print text_wrapper.fill(" ".join(openssl_cmd)).replace('\n', ' \\\n')
+        print("# {0}\n$".format(cert), end='')
+        print(text_wrapper.fill(" ".join(openssl_cmd)).replace('\n', ' \\\n'))
 
         return first_line
 
@@ -221,7 +227,7 @@ def install_ocsp_certificates(cert_file_locations, ocsp_out_dir):
     """Copy good certs from temporary location to final target name"""
     do_reload = False
     ocsp_file_ext = '.pem.ocsp'
-    for cert, keys in cert_file_locations.items():
+    for cert, keys in list(cert_file_locations.items()):
         if keys.get('ocsp', None):
             if os.path.isfile(keys['ocsp']) and (
                     os.path.getsize(keys['ocsp']) > 0):

--- a/haproxy/files/update_ocsp
+++ b/haproxy/files/update_ocsp
@@ -30,8 +30,8 @@ try:
     import salt.client
 except ImportError:
     sys.stderr.write(
-        os.path.join(["Failed to load the Salt Stack client library.\n",
-                      "Try installing the salt-common package.\n"]))
+        ("Failed to load the Salt Stack client library.\n"
+         "Try installing the salt-common package.\n"))
     sys.exit(1)
 
 


### PR DESCRIPTION
This includes a fix for these exception errors I get e-mailed each night:
```
Traceback (most recent call last):
  File "/usr/local/sbin/update_ocsp", line 262, in <module>
    main()
  File "/usr/local/sbin/update_ocsp", line 257, in main
    install_ocsp_certificates(cert_file_locations, args['ocsp_out_dir'])
  File "/usr/local/sbin/update_ocsp", line 233, in install_ocsp_certificates
    reload_haproxy()
  File "/usr/local/sbin/update_ocsp", line 205, in reload_haproxy
    subprocess.check_call(reload_cmd, stdout=null_file)
  File "/usr/lib/python2.7/subprocess.py", line 181, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 168, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 390, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1024, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

Paul Vixie's 4th BSD edition cron defaults to `/usr/bin:/bin` and seeing as this is a salt-formula that could be used by anyone for anything, adjusting the system's root crontab file's `PATH` environment variable instead would just be rude.

Also adds Python 3 compatibility support, as will be required by newer Salt releases.