### PR TITLE
SitePoint dhparams support

### DIFF
--- a/haproxy/config.sls
+++ b/haproxy/config.sls
@@ -1,8 +1,25 @@
+{%- if salt['pillar.get']('haproxy:dhparam') %}
+haproxy.dhparam:
+  file.managed:
+    - name: {{ salt['pillar.get']('haproxy:dhparam_file_path', '/etc/haproxy/dhparam') }}
+    - contents_pillar: 'haproxy:dhparam'
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pkg: haproxy.install
+{%- endif %}
+
 haproxy.config:
- file.managed:
-   - name: {{ salt['pillar.get']('haproxy:config_file_path', '/etc/haproxy/haproxy.cfg') }}
-   - source: salt://haproxy/templates/haproxy.jinja
-   - template: jinja
-   - user: root
-   - group: root
-   - mode: 644
+  file.managed:
+    - name: {{ salt['pillar.get']('haproxy:config_file_path', '/etc/haproxy/haproxy.cfg') }}
+    - source: salt://haproxy/templates/haproxy.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pkg: haproxy.install
+{%- if salt['pillar.get']('haproxy:dhparam') %}
+      - file: {{ salt['pillar.get']('haproxy:dhparam_file_path', '/etc/haproxy/dhparam') }}
+{%- endif %}

--- a/haproxy/files/update_ocsp
+++ b/haproxy/files/update_ocsp
@@ -177,7 +177,7 @@ def execute_openssl_ocsp_command(cert_file_locations, verbose):
         ).rstrip()
         ocsp_host = urlparse(ocsp_url).netloc
 
-        if not len(ocsp_url):
+        if not ocsp_url:
             continue
 
         openssl_cmd = ['openssl', 'ocsp', '-noverify']

--- a/haproxy/service.sls
+++ b/haproxy/service.sls
@@ -14,6 +14,9 @@ haproxy.service:
 {% endif %}
     - watch:
       - file: haproxy.config
+{%- if salt['pillar.get']('haproxy:dhparam') %}
+      - file: haproxy.dhparam
+{%- endif %}
 {% if 'ssl' in salt['pillar.items']() %}
 {% for ssl_cert in salt['pillar.get']('ssl') %}
       - file: /etc/haproxy/certs/{{ ssl_cert }}.pem


### PR DESCRIPTION
ClickUp: No card

Related to a security report, whereby our cert setup is vulnerable to a BEAST attack (for example).

Implementing dhparam support is recommended by Mozilla, and should help improve our security score.