### PR TITLE
Support optional username/password key separation

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -185,6 +185,8 @@ listen {{ listener_config.name|default(listener) }}
     stats enable
         {%- elif option == 'hide_version' and value %}
     stats hide-version
+        {%- elif option == 'auth' and 'username' in value and 'password' in value %}
+    stats auth {{ value['username'] }}:{{ value['password'] }}
         {%- else %}
     stats {{ option }} {{ value }}
         {%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -140,7 +140,9 @@ haproxy:
         enable: True
         uri: /url/to/stats
         realm: LoadBalancer
-        auth: "user:password"
+        auth:
+          username: username
+          password: password
       servers:
         some-server:
           host: 123.156.189.111


### PR DESCRIPTION
ClickUp: https://app.clickup.com/t/35rggba

I'm attempting to have the output of HAProxy pillar pipped through the atpass renderer, but it will only work if the secret has a key all of its own. As such, the state formula needs to be updated to support such a setup.