### PR TITLE
Add support for HAProxy map file deployments

### DIFF
--- a/haproxy/config.sls
+++ b/haproxy/config.sls
@@ -8,7 +8,28 @@ haproxy.dhparam:
     - mode: 644
     - require:
       - pkg: haproxy.install
+    - require_in:
+      - file: haproxy.config
 {%- endif %}
+
+{%- for path, mappings in salt["pillar.get"]("haproxy:map_files", {}).items() %}
+HAProxy map file {{ path }}:
+  file.managed:
+    - name: {{ path }}
+    - contents: |-
+{%- for key, value in mappings.items() %}
+        {{ key }}  {{ value }}
+{%- endfor %}
+    - makedirs: True
+    - user: root
+    - group: root
+    - mode: 644
+    - dir_mode: '0755'
+    - require:
+      - pkg: haproxy.install
+    - require_in:
+      - file: haproxy.config
+{%- endfor %}
 
 haproxy.config:
   file.managed:
@@ -20,6 +41,3 @@ haproxy.config:
     - mode: 644
     - require:
       - pkg: haproxy.install
-{%- if salt['pillar.get']('haproxy:dhparam') %}
-      - file: {{ salt['pillar.get']('haproxy:dhparam_file_path', '/etc/haproxy/dhparam') }}
-{%- endif %}

--- a/haproxy/service.sls
+++ b/haproxy/service.sls
@@ -17,6 +17,9 @@ haproxy.service:
 {%- if salt['pillar.get']('haproxy:dhparam') %}
       - file: haproxy.dhparam
 {%- endif %}
+{%- for path in salt["pillar.get"]("haproxy:map_files", []) %}
+      - file: HAProxy map file {{ path }}
+{%- endfor %}
 {% if 'ssl' in salt['pillar.items']() %}
 {% for ssl_cert in salt['pillar.get']('ssl') %}
       - file: /etc/haproxy/certs/{{ ssl_cert }}.pem

--- a/pillar.example
+++ b/pillar.example
@@ -61,6 +61,11 @@ haproxy:
         - timeout retry 1s
         - hold valid 10s
 
+  map_files:
+    /etc/haproxy/www.sitepoint.com-rates.map:
+      /slowpage.php: 5
+      /fastpage.php: 80
+
   listens:
     stats:
       bind:


### PR DESCRIPTION
ClickUp: None

Allows for map files to be deployed. HAProxy will reload if anything was deployed so that any map changes will immediately take effect.