### PR TITLE
Prevent the logging of private key diffs

### DIFF
--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -247,6 +247,9 @@ Schedule regular update_ocsp executions via cron:
         {{ ssl_certs[cert_type].rstrip()|indent(8) }}
 {%- endif %}
 {%- endfor %}
+{%- if "key" in ssl_certs %}
+    - show_changes: False
+{% endif %}
     - require:
       - file: /etc/haproxy/certs
     - watch_in:


### PR DESCRIPTION
ClickUp: None

Prevent us logging SSL private key diffs on updates.

Staging run with manual cert modifications for testing:
```
abolte@salt-master1:/srv/formulas$ sudo salt 'rproxy*' state.highstate
rproxy1.us-west-2b.sitepoint-staging.internal:
----------
          ID: /etc/haproxy/certs/articles.us-west-2b.sitepoint-staging.sitepoint.com.pem
    Function: file.managed
      Result: True
     Comment: File /etc/haproxy/certs/articles.us-west-2b.sitepoint-staging.sitepoint.com.pem updated
     Started: 16:59:48.370400
    Duration: 3.132 ms
     Changes:   
              ----------
              diff:
                  <show_changes=False>
----------
          ID: /usr/local/sbin/update_ocsp
    Function: cmd.wait
        Name: /usr/local/sbin/update_ocsp /etc/haproxy/certs
      Result: True
     Comment: Command "/usr/local/sbin/update_ocsp /etc/haproxy/certs" run
     Started: 16:59:48.396791
    Duration: 5270.338 ms
     Changes:   
              ----------
              pid:
                  745409
              retcode:
                  0
              stderr:
              stdout:
----------
          ID: haproxy.service
    Function: service.running
        Name: haproxy
      Result: True
     Comment: Service reloaded
     Started: 16:59:57.033300
    Duration: 110.372 ms
     Changes:   
              ----------
              haproxy:
                  True

Summary for rproxy1.us-west-2b.sitepoint-staging.internal
--------------
Succeeded: 357 (changed=3)
Failed:      0
--------------
Total states run:     357
Total run time:    19.715 s
abolte@salt-master1:/srv/formulas$ 
```