### PR TITLE
Add support for tcp-check in background sections

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -323,6 +323,11 @@ backend {{ backend_config.name|default(backend) }}
     http-check {{ h_c }}
       {%- endfor %}
     {%- endif %}
+    {%- if 'tcp_check' in backend_config %}
+      {%- for h_c in backend_config.tcp_check %}
+    tcp-check {{ h_c }}
+      {%- endfor %}
+    {%- endif %}
     {%- if 'cookie' in backend_config %}
     cookie {{ backend_config.cookie }}
     {%- endif %}


### PR DESCRIPTION
Card: None

Related to implementing a work-around for Node now blowing up when a HEAD request in a health check contains a `content-length: 0` header, which HAProxy sends automatically and cannot be switched off (without upgrading to a newer release).

