### PR TITLE
Fix for incorrect usage of cmd.wait env setting

### DIFF
--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -215,6 +215,16 @@ Delete {{ setting }} from {{ logrotate_config }}:
 {%- set python_path = "/opt/saltstack/salt/bin" %}
 {%- set update_ocsp_path = "/usr/local/sbin/update_ocsp" %}
 {%- set update_ocsp_cmd = update_ocsp_path + ' /etc/haproxy/certs' %}
+{%-
+  set current_path = salt['environ.get'](
+    "PATH",
+    (
+        "/usr/local/sbin:/usr/local/bin:"
+        "/usr/sbin:/usr/bin:"
+        "/sbin:/bin"
+    ),
+  )
+%}
 
 {{ update_ocsp_path }}:
   file.managed:
@@ -226,7 +236,8 @@ Delete {{ setting }} from {{ logrotate_config }}:
       - pkg: haproxy
   cmd.wait:
     - name: {{ update_ocsp_cmd }}
-    - env: "PATH={{ python_path }}:${PATH}"
+    - env:
+      - PATH: {{ [python_path, current_path]|join(':') }}
     - require:
       - file: {{ update_ocsp_path }}
 


### PR DESCRIPTION
Fixes the incorrect usage of `env` in the haproxy.install state file.

Based on the example in the docs:
https://docs.saltproject.io/en/latest/ref/states/all/salt.states.cmd.html#salt.states.cmd.wait

Warning: ignore this documented example:
```
script-bar:
  cmd.wait:
    - env: "PATH=/some/path:$PATH"
```

The use of PATH in the above (lifted straight from the documentation) is deliberately incorrect — it pays to read the text explaining the purpose of the example as well — but it is unclear if this is attempting to demonstrate incorrect usage of formatting as well, or it's just a bug in the example. Either way, this PR fixes both issues.