### PR TITLE
Support a per-certificate deployment directory

### DIFF
--- a/haproxy/config.sls
+++ b/haproxy/config.sls
@@ -1,3 +1,6 @@
+include:
+  - haproxy.install
+
 {%- if salt['pillar.get']('haproxy:dhparam') %}
 haproxy.dhparam:
   file.managed:

--- a/haproxy/files/update_ocsp
+++ b/haproxy/files/update_ocsp
@@ -71,8 +71,9 @@ def setup_argparser():
     return vars(parser_args)
 
 
-def get_certs_from_pillar():
+def get_certs_from_pillar(ocsp_out_dir: str) -> dict:
     """Return 'ssl' keys from Salt pillar as a dict"""
+    results = {}
     # Create a local client Caller object
     try:
         caller = salt.client.Caller()
@@ -91,11 +92,20 @@ def get_certs_from_pillar():
         sys.exit(1)
 
     try:
-        results = caller.function("pillar.get", "ssl")
+        ssl_pillar = caller.function("pillar.get", "ssl")
+        haproxy_certs = caller.function("pillar.get", "haproxy:cert_dirs")
     except salt.exceptions.SaltException as exception:
         sys.stderr.write("Failure:\n{0}\n".format(exception))
         sys.exit(1)
 
+    # Strip a trailing slash from a directory key in haproxy_certs.
+    for key in list(haproxy_certs.keys()):
+        haproxy_certs[key.rstrip("/")] = haproxy_certs.pop(key)
+
+    # Get certs allocated to the requested directory.
+    if ocsp_out_dir.rstrip("/") in haproxy_certs:
+        for cert in haproxy_certs[ocsp_out_dir.rstrip("/")]:
+            results[cert] = ssl_pillar[cert]
     return results
 
 
@@ -305,7 +315,7 @@ def main():
     """Begin execution"""
     extend_system_path(["/sbin", "/usr/sbin"])
     args = setup_argparser()
-    ssl_pillar = get_certs_from_pillar()
+    ssl_pillar = get_certs_from_pillar(args["ocsp_out_dir"])
     cert_file_locations = write_certs_to_disk(ssl_pillar)
     execute_openssl_ocsp_command(cert_file_locations, args["verbose"])
     install_ocsp_certificates(cert_file_locations, args["ocsp_out_dir"])

--- a/haproxy/init.sls
+++ b/haproxy/init.sls
@@ -11,3 +11,10 @@ include:
   - haproxy.install
   - haproxy.service
   - haproxy.config
+
+HAProxy state complete:
+  test.succeed_without_changes:
+    - require:
+      - sls: haproxy.install
+      - sls: haproxy.service
+      - sls: haproxy.config

--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -5,12 +5,12 @@
   )
 %}
 
-{% if salt['pillar.get']('haproxy:include') %}
 include:
+  - haproxy.config
+  - haproxy.service
 {% for item in salt['pillar.get']('haproxy:include') %}
   - {{ item }}
 {% endfor %}
-{% endif %}
 
 # If on Ubuntu, add a PPA to use the latest HAProxy releases.
 {% if salt['grains.get']('osfullname') == 'Ubuntu' %}
@@ -39,6 +39,7 @@ Restart rsyslog on haproxy package install:
     - name: rsyslog
     - watch:
       - pkg: haproxy
+      - file: haproxy.config
 {% if salt['pillar.get']('haproxy:log_file_path') %}
       - file: Update old-style HAProxy log file path in {{ syslog_file_path }}
       - file: Update new-style HAProxy log file path in {{ syslog_file_path }}
@@ -202,19 +203,10 @@ Delete {{ setting }} from {{ logrotate_config }}:
 {% endfor %}
 {% endif %}
 
-# Handle OCSP stapling.
-{% if 'ssl' in salt['pillar.items']() %}
-/etc/haproxy/certs:
-  file.directory:
-    - user: root
-    - group: {{ salt['pillar.get']('haproxy:global:group', 'haproxy') }}
-    - mode: '0750'
-    - require:
-      - pkg: haproxy
 
+# Handle cert dirs and OCSP stapling.
 {%- set python_path = "/opt/saltstack/salt/bin" %}
 {%- set update_ocsp_path = "/usr/local/sbin/update_ocsp" %}
-{%- set update_ocsp_cmd = update_ocsp_path + ' /etc/haproxy/certs' %}
 {%-
   set current_path = salt['environ.get'](
     "PATH",
@@ -226,34 +218,59 @@ Delete {{ setting }} from {{ logrotate_config }}:
   )
 %}
 
-{{ update_ocsp_path }}:
+Deploy {{ update_ocsp_path }}:
   file.managed:
+    - name: {{ update_ocsp_path }}
     - user: root
     - group: root
     - mode: '0700'
     - source: salt://haproxy/files/update_ocsp
     - requires:
       - pkg: haproxy
+
+{%-
+  for dir_name in salt["pillar.get"](
+    "haproxy:cert_dirs", ["/etc/haproxy/certs"]
+  )
+%}
+{%- set update_ocsp_cmd = update_ocsp_path ~ " " ~ dir_name %}
+{{ dir_name }}:
+  file.directory:
+    - user: root
+    - group: {{ salt['pillar.get']('haproxy:global:group', 'haproxy') }}
+    - mode: '0750'
+    - require:
+      - pkg: haproxy
+
+Run '{{ update_ocsp_cmd }}':
   cmd.wait:
     - name: {{ update_ocsp_cmd }}
     - env:
       - PATH: {{ [python_path, current_path]|join(':') }}
     - require:
-      - file: {{ update_ocsp_path }}
+      - file: Deploy {{ update_ocsp_path }}
 
-Schedule regular update_ocsp executions via cron:
+Schedule regular update_ocsp executions via cron for {{ dir_name }}:
   cron.present:
     - name: sh -c 'PATH="{{ python_path }}:${PATH}" {{ update_ocsp_cmd }}'
-    - identifier: HAPROXY_OCSP_UPDATE
+    - identifier: HAPROXY_OCSP_UPDATE-{{ dir_name }}
     - user: root
     - minute: 0
     - hour: '*/6'
     - require:
       - file: {{ update_ocsp_path }}
+{%- endfor %}
 
+{%-
+  for hap_cert_dir, hap_cert_names in salt["pillar.get"](
+    "haproxy:cert_dirs", {}
+  ).items()
+%}
 {%- for ssl_name, ssl_certs in salt['pillar.get']('ssl', {}).items() %}
-/etc/haproxy/certs/{{ ssl_name }}.pem:
+{%- if ssl_name in hap_cert_names %}
+Deploy {{ hap_cert_dir }}{{ ssl_name }}.pem:
   file.managed:
+    - name: {{ hap_cert_dir }}{{ ssl_name }}.pem
     - user: root
     - group: www-data
     - mode: '0640'
@@ -265,10 +282,12 @@ Schedule regular update_ocsp executions via cron:
 {%- endfor %}
 {%- if "key" in ssl_certs %}
     - show_changes: False
-{% endif %}
+{%- endif %}
     - require:
-      - file: /etc/haproxy/certs
+      - file: {{ hap_cert_dir }}
     - watch_in:
-      - cmd: {{ update_ocsp_path }}
-{% endfor %}
-{% endif %}
+      - cmd: Run '{{ update_ocsp_path }} {{ hap_cert_dir }}'
+      - service: haproxy.service
+{%- endif %}
+{%- endfor %}
+{%- endfor %}

--- a/haproxy/service.sls
+++ b/haproxy/service.sls
@@ -1,3 +1,7 @@
+include:
+  - haproxy.install
+  - haproxy.config
+
 haproxy.service:
 {% if salt['pillar.get']('haproxy:enable', True) %}
   service.running:
@@ -7,11 +11,6 @@ haproxy.service:
     - require:
       - pkg: haproxy
         file: haproxy.service
-{% if 'ssl' in salt['pillar.items']() %}
-{% for ssl_cert in salt['pillar.get']('ssl') %}
-      - file: /etc/haproxy/certs/{{ ssl_cert }}.pem
-{% endfor %}
-{% endif %}
     - watch:
       - file: haproxy.config
 {%- if salt['pillar.get']('haproxy:dhparam') %}
@@ -20,11 +19,6 @@ haproxy.service:
 {%- for path in salt["pillar.get"]("haproxy:map_files", []) %}
       - file: HAProxy map file {{ path }}
 {%- endfor %}
-{% if 'ssl' in salt['pillar.items']() %}
-{% for ssl_cert in salt['pillar.get']('ssl') %}
-      - file: /etc/haproxy/certs/{{ ssl_cert }}.pem
-{% endfor %}
-{% endif %}
 {% else %}
   service.dead:
     - name: haproxy

--- a/pillar.example
+++ b/pillar.example
@@ -12,6 +12,13 @@ haproxy:
     deletes:
       - badoption
   logrotate_file_path: /etc/logrotate.d/haproxy
+
+  # Directories containing certificates for deployment.
+  # Certificates must be provided within "ssl" pillar.
+  cert_dirs:
+    /etc/haproxy/certs/:
+      - 000-example.com
+
   global:
     stats:
       enable: True


### PR DESCRIPTION
## Card
[Total CloudFront bypass for API calls](https://app.vanillaapps.com/2/tasks/task/113)

## Description
Eliminate the requirement to have all TLS certificates deployed under the `/etc/haproxy/certs/` directory. Instead, the directory can now be specified on a per-certificate basis.
