### PR TITLE
Let backend "check" directive be optional

### DIFF
--- a/haproxy/templates/haproxy.jinja
+++ b/haproxy/templates/haproxy.jinja
@@ -200,7 +200,7 @@ listen {{ listener_config.name|default(listener) }}
     {%- endif %}
     {%- if 'servers' in listener_config and listener_config.servers is iterable() %}
       {%- for server, server_config in listener_config.servers.items()|sort %}
-    server {{ server_config.name|default(server) }} {{ server_config.host }}:{{ server_config.port }} {{ server_config.check }}
+    server {{ server_config.name|default(server) }} {{ server_config.host }}:{{ server_config.port }} {{ server_config.check|default('') }}
       {%- endfor %}
     {%- endif -%}
     {%- if 'mine_servers_module' in listener_config and 'mine_servers' in listener_config %}
@@ -386,7 +386,7 @@ backend {{ backend_config.name|default(backend) }}
     {%- endif %}
     {%- if 'servers' in backend_config and backend_config.servers is iterable() %}
       {%- for server, server_config in backend_config.servers.items()|sort %}
-    server {{ server_config.name|default(server) }} {{ server_config.host }}:{{ server_config.port }} {{ server_config.check }} {{ server_config.extra|default('') }}
+    server {{ server_config.name|default(server) }} {{ server_config.host }}:{{ server_config.port }} {{ server_config.check|default('') }} {{ server_config.extra|default('') }}
       {%- endfor %}
     {%- endif %}
     {%- if 'mine_servers_module' in backend_config and 'mine_servers' in backend_config %}


### PR DESCRIPTION
## Card
None

## Description
Prevent a haproxy pillar data rendering error if the optional _check_ directive is not set for every backend.