### PR TITLE
Dependency fix and legacy Ubuntu PPA removal

### DIFF
--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -12,15 +12,6 @@ include:
   - {{ item }}
 {% endfor %}
 
-# If on Ubuntu, add a PPA to use the latest HAProxy releases.
-{% if salt['grains.get']('osfullname') == 'Ubuntu' %}
-haproxy_ppa_repo:
-  pkgrepo.managed:
-    - ppa: vbernat/haproxy-1.5
-    - require_in:
-      - pkg: haproxy.install
-{% endif %}
-
 haproxy.install:
   pkg.installed:
     - name: haproxy

--- a/haproxy/install.sls
+++ b/haproxy/install.sls
@@ -61,6 +61,8 @@ Restart rsyslog on haproxy package install:
         </body></html>
     - require:
       - pkg: haproxy.install
+    - require_in:
+      - service: haproxy.service
 
 {% if 'log_file_path' in salt['pillar.get']('haproxy') %}
 Create the HAProxy logging output directory:
@@ -71,6 +73,8 @@ Create the HAProxy logging output directory:
     - user: root
     - group: adm
     - mode: '0750'
+    - require_in:
+      - service: haproxy.service
 {% endif %}
 
 # Handle rsyslog configuration directives.


### PR DESCRIPTION
## Card
None. Deployment fix.

## Description
This was the output when bringing up a new rproxy host and running the haproxy state for the first time:
```
----------
          ID: haproxy.service
    Function: service.running
        Name: haproxy
      Result: False
     Comment: Job for haproxy.service failed.
              See "systemctl status haproxy.service" and "journalctl -xeu haproxy.service" for details.
     Started: 01:27:33.061410
    Duration: 151.301 ms
     Changes:   
----------
          ID: /etc/haproxy/errors/200.http
    Function: file.managed
      Result: True
     Comment: File /etc/haproxy/errors/200.http updated
     Started: 01:27:33.218537
    Duration: 3.469 ms
     Changes:   
              ----------
              diff:
                  New file
----------
          ID: Create the HAProxy logging output directory
    Function: file.directory
        Name: /var/log/haproxy
      Result: True
     Comment: 
     Started: 01:27:33.222223
    Duration: 1.901 ms
     Changes:   
              ----------
              /var/log/haproxy:
                  ----------
                  directory:
                      new
----------
          ID: Update new-style HAProxy log file path in /etc/rsyslog.d/49-haproxy.conf
    Function: file.replace
        Name: /etc/rsyslog.d/49-haproxy.conf
      Result: True
     Comment: Changes were made
     Started: 01:27:33.231447
    Duration: 4.155 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -4,6 +4,6 @@
                   
                   # Send HAProxy messages to a dedicated logfile
                   :programname, startswith, "haproxy" {
                  -  /var/log/haproxy.log
                  +  /var/log/haproxy/haproxy.log
                     stop
                   }
----------
          ID: Update HAProxy log file path in /etc/logrotate.d/haproxy
    Function: file.replace
        Name: /etc/logrotate.d/haproxy
      Result: True
     Comment: Changes were made
     Started: 01:27:33.237732
    Duration: 3.607 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -1,4 +1,4 @@
                  -/var/log/haproxy.log {
                  +/var/log/haproxy/haproxy.log {
                       daily
                       rotate 7
                       missingok
----------
          ID: Update rotate value in /etc/logrotate.d/haproxy
    Function: file.replace
        Name: /etc/logrotate.d/haproxy
      Result: True
     Comment: Changes were made
     Started: 01:27:35.095569
    Duration: 4.232 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -1,6 +1,6 @@
                   /var/log/haproxy/haproxy.log {
                       daily
                  -    rotate 7
                  +    rotate 72
                       missingok
                       notifempty
                       compress
----------
          ID: Add hourly to /etc/logrotate.d/haproxy
    Function: file.replace
        Name: /etc/logrotate.d/haproxy
      Result: True
     Comment: Changes were made
     Started: 01:27:35.101195
    Duration: 13.881 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -8,4 +8,5 @@
                       postrotate
                           [ ! -x /usr/lib/rsyslog/rsyslog-rotate ] || /usr/lib/rsyslog/rsyslog-rotate
                       endscript
                  +    hourly
                   }
----------
          ID: Delete daily from /etc/logrotate.d/haproxy
    Function: file.replace
        Name: /etc/logrotate.d/haproxy
      Result: True
     Comment: Changes were made
     Started: 01:27:35.121560
    Duration: 3.535 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -1,5 +1,4 @@
                   /var/log/haproxy/haproxy.log {
                  -    daily
                       rotate 72
                       missingok
                       notifempty
----------
          ID: Deploy /usr/local/sbin/update_ocsp
    Function: file.managed
        Name: /usr/local/sbin/update_ocsp
      Result: True
     Comment: File /usr/local/sbin/update_ocsp updated
     Started: 01:27:35.125318
    Duration: 30.069 ms
     Changes:   
              ----------
              diff:
                  New file
              mode:
                  0700
----------
          ID: Run '/usr/local/sbin/update_ocsp /etc/haproxy/certs/'
    Function: cmd.wait
        Name: /usr/local/sbin/update_ocsp /etc/haproxy/certs/
      Result: True
     Comment: Command "/usr/local/sbin/update_ocsp /etc/haproxy/certs/" run
     Started: 01:27:35.168684
    Duration: 7240.129 ms
     Changes:   
              ----------
              pid:
                  9549
              retcode:
                  0
              stderr:
              stdout:
----------
          ID: Schedule regular update_ocsp executions via cron for /etc/haproxy/certs/
    Function: cron.present
        Name: sh -c 'PATH="/opt/saltstack/salt/bin:${PATH}" /usr/local/sbin/update_ocsp /etc/haproxy/certs/'
      Result: True
     Comment: Cron sh -c 'PATH="/opt/saltstack/salt/bin:${PATH}" /usr/local/sbin/update_ocsp /etc/haproxy/certs/' added to root's crontab
     Started: 01:27:42.410637
    Duration: 9.664 ms
     Changes:   
              ----------
              root:
                  sh -c 'PATH="/opt/saltstack/salt/bin:${PATH}" /usr/local/sbin/update_ocsp /etc/haproxy/certs/'
----------
          ID: HAProxy state complete
    Function: test.succeed_without_changes
      Result: False
     Comment: One or more requisite failed: haproxy.service.haproxy.service
     Started: 01:27:42.423397
    Duration: 0.007 ms
     Changes:   
```


The service was seemingly left running (as is the default for Debian packages), but it failed to reload the configuration. The error file and the log directory were subsequently deployed successfully. Re-running the state did not do anything either since no changes were reported as being required — one of the worst possible scenarios.

With these changes in place, this shouldn't happen again.